### PR TITLE
Replaced "burnbright/silverstripe-shop" dependency with "silvershop/core"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 	}],
 	"require": {
 		"silverstripe/framework": "~3.1",
-		"burnbright/silverstripe-shop": "*"
+    "silvershop/core": "~1.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 	}],
 	"require": {
 		"silverstripe/framework": "~3.1",
-    "silvershop/core": "~1.0"
+    "silvershop/core": "~1.0 || ~2.0"
 	}
 }


### PR DESCRIPTION
This is required to keep from having two instances of the SilverShop add-on.
